### PR TITLE
Fix update checker

### DIFF
--- a/src/main/java/me/noodles/gui/PunishmentGUI.java
+++ b/src/main/java/me/noodles/gui/PunishmentGUI.java
@@ -98,6 +98,7 @@ public class PunishmentGUI extends JavaPlugin
         guicommands1 = YamlConfiguration.loadConfiguration(guicommands);
     }
 
+    public static PunishmentGUI getPlugin() { return plugin; }
     public static Plugin getInstance() {
         return instance;
     }

--- a/src/main/java/me/noodles/gui/updatechecker/JoinEvents.java
+++ b/src/main/java/me/noodles/gui/updatechecker/JoinEvents.java
@@ -11,15 +11,12 @@ import org.bukkit.event.*;
 
 public class JoinEvents implements Listener {
 
-    public UpdateChecker checker;
-    private PunishmentGUI plugin;
-
     @EventHandler
     public void onJoin(final PlayerJoinEvent e) {
         Player p = e.getPlayer();
         if (PunishmentGUI.plugin.getConfig().getBoolean("Update.Enabled") == true) {
             if (p.hasPermission("punishmentgui.update")) {
-                new UpdateChecker(plugin, 52072).getLatestVersion(version -> {
+                new UpdateChecker(PunishmentGUI.getPlugin(), 52072).getLatestVersion(version -> {
                     if (!PunishmentGUI.getInstance().getDescription().getVersion().equalsIgnoreCase(version)) {
                         p.sendMessage(ChatColor.GRAY + "****************************************************************");
                         p.sendMessage(ChatColor.RED + "PunishmentGUI is outdated!");
@@ -31,7 +28,6 @@ public class JoinEvents implements Listener {
             }
         }
     }
-
 
     @EventHandler
     public void onDevJoin(PlayerJoinEvent e) { //THIS EVENT IS USED FOR DEBUG REASONS ONLY!


### PR DESCRIPTION
An `IllegalArgumentException` on the player join event caused but passing **`null`** to `UpdateChecker()` constructor, solved by creating a static method in the main plugin to access the static reference of the plugin created in the `onEnable()` method.

Could also be solved by changing the type from `PunishmentGUI` to `Bukkit#Plugin` and passing in the existing `getInstance()` method instead.