### PR TITLE
Added support for item byte, fixed configuration reload

### DIFF
--- a/src/main/java/me/noodles/gui/PunishmentGUI.java
+++ b/src/main/java/me/noodles/gui/PunishmentGUI.java
@@ -1,16 +1,13 @@
 package me.noodles.gui;
 
-import java.io.File;
-import java.io.IOException;
-
 import me.noodles.gui.commands.PunishmentGUICommand;
 import me.noodles.gui.commands.PunishmentGUIReloadCommand;
+import me.noodles.gui.util.config.CustomConfig;
+import me.noodles.gui.util.config.IConfig;
 import me.noodles.gui.util.Logger;
 import me.noodles.gui.util.MetricsLite;
 import me.noodles.gui.util.Settings;
-import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -41,15 +38,15 @@ public class PunishmentGUI extends JavaPlugin
         instance = this;
         MetricsLite metrics = new MetricsLite(this);
         Logger.log(Logger.LogLevel.INFO, "Managers Registered!");
+        Logger.log(Logger.LogLevel.INFO, "Loading Config's...");
+        this.createFiles();
+        Logger.log(Logger.LogLevel.INFO, "Config's Registered!");
         Logger.log(Logger.LogLevel.INFO, "Registering Listeners...");
         this.registerEvents();
         Logger.log(Logger.LogLevel.INFO, "Listeners Registered!");
         Logger.log(Logger.LogLevel.INFO, "Registering Commands...");
         this.registerCommands();
         Logger.log(Logger.LogLevel.INFO, "Commands Registered!");
-        Logger.log(Logger.LogLevel.INFO, "Loading Config's...");
-        this.createFiles();
-        Logger.log(Logger.LogLevel.INFO, "Config's Registered!");
         Logger.log(Logger.LogLevel.SUCCESS, "PunishmentGUI Version: " + Settings.VERSION + " Loaded.");
         this.setEnabled(true);
         Logger.log(Logger.LogLevel.OUTLINE,  "*********************************************************************");
@@ -76,26 +73,25 @@ public class PunishmentGUI extends JavaPlugin
         this.getCommand("punish").setExecutor(new Punish());
         this.getCommand("punishmentgui").setExecutor(new PunishmentGUICommand());
         this.getCommand("punishmentguireload").setExecutor(new PunishmentGUIReloadCommand());
+    }
 
-    }
-    
-    private File configf, guiitems, banreason, guicommands;
-    private FileConfiguration config, guiitems1, banreason1, guicommands1;
-    public FileConfiguration getguiitems1Config() {
-        return this.guiitems1;
-    }
+    private IConfig customConfig, guiConfig, banConfig, guiCommands;
+
+    @Override
+    public FileConfiguration getConfig() { return this.customConfig.getConfig(); }
+    public FileConfiguration getguiitems1Config() { return this.guiConfig.getConfig(); }
     public FileConfiguration getbanreason1Config() {
-        return this.banreason1;
+        return this.banConfig.getConfig();
     }
     public FileConfiguration getguicommands1Config() {
-        return this.guicommands1;
+        return this.guiCommands.getConfig();
     }
 
     public void reloadFiles() {
-        config = YamlConfiguration.loadConfiguration(configf);
-        guiitems1 = YamlConfiguration.loadConfiguration(guiitems);
-        banreason1 = YamlConfiguration.loadConfiguration(banreason);
-        guicommands1 = YamlConfiguration.loadConfiguration(guicommands);
+        this.customConfig.reloadConfig();
+        this.guiConfig.reloadConfig();
+        this.banConfig.reloadConfig();
+        this.guiCommands.reloadConfig();
     }
 
     public static PunishmentGUI getPlugin() { return plugin; }
@@ -104,40 +100,10 @@ public class PunishmentGUI extends JavaPlugin
     }
 
     private void createFiles() {
-        configf = new File(getDataFolder(), "config.yml");
-        guiitems = new File(getDataFolder(), "guiitems.yml");
-        banreason = new File(getDataFolder(), "banreason.yml");
-        guicommands = new File(getDataFolder(), "guicommands.yml");
-
-        if (!configf.exists()) {
-            configf.getParentFile().mkdirs();
-            saveResource("config.yml", false);
-        }
-        if (!guiitems.exists()) {
-            guiitems.getParentFile().mkdirs();
-            saveResource("guiitems.yml", false);
-         }
-        if (!banreason.exists()) {
-            banreason.getParentFile().mkdirs();
-            saveResource("banreason.yml", false);
-         }
-        if (!guicommands.exists()) {
-            guicommands.getParentFile().mkdirs();
-            saveResource("guicommands.yml", false);
-        }
-        config = new YamlConfiguration();
-        guiitems1 = new YamlConfiguration();
-        banreason1 = new YamlConfiguration();
-        guicommands1 = new YamlConfiguration();
-
-        try {
-            config.load(configf);
-            guiitems1.load(guiitems);
-            banreason1.load(banreason);
-            guicommands1.load(guicommands);
-        } catch (IOException | InvalidConfigurationException e) {
-            e.printStackTrace();
-        }
+        customConfig = new CustomConfig(this, "config.yml");
+        guiConfig = new CustomConfig(this, "guiitems.yml");
+        banConfig = new CustomConfig(this, "banreason.yml");
+        guiCommands = new CustomConfig(this, "guicommands.yml");
     }
     
 }

--- a/src/main/java/me/noodles/gui/inv/Items.java
+++ b/src/main/java/me/noodles/gui/inv/Items.java
@@ -1,8 +1,8 @@
 package me.noodles.gui.inv;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.IntStream;
+
+import com.google.common.collect.Lists;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -14,192 +14,151 @@ import me.noodles.gui.PunishmentGUI;
 public class Items {
 
     public static ItemStack Glass(Player p) {
-        ItemStack stone = new ItemStack(Material.STAINED_GLASS_PANE, 1, (short)7);
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(" ");
-        stone.setItemMeta(stonem);
-        return stone;
+        List<String> _item = Lists.newArrayList(PunishmentGUI.plugin.getguiitems1Config().getString("GUIFillerItem", "STAINED_GLASS_PANE:7").split(":"));
+        if (_item.size() == 1) _item.add(String.valueOf(0));
+
+        ItemStack itemStack = new ItemStack(Material.getMaterial(_item.get(0)), 1, Short.parseShort(_item.get(1)));
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        itemMeta.setDisplayName(" ");
+        itemStack.setItemMeta(itemMeta);
+        return itemStack;
     }
-	
-    
+
     private static String getColor(String msg) {
         return ChatColor.translateAlternateColorCodes('&', msg);
     }
 
+    private static ItemStack createItemFromConfig(String item, String name, List<String> lore) {
+        List<String> _item = Lists.newArrayList(item.split(":"));
+        if (_item.size() == 1) _item.add(String.valueOf(0));
+
+        ItemStack _itemStack = new ItemStack(Material.getMaterial(_item.get(0)), 1, Short.parseShort(_item.get(1)));
+
+        ItemMeta _itemMeta = _itemStack.getItemMeta();
+        _itemMeta.setDisplayName(getColor(name));
+
+        lore.replaceAll(Items::getColor);
+        _itemMeta.setLore(lore);
+
+        _itemStack.setItemMeta(_itemMeta);
+        return _itemStack;
+    }
+
     
     public static ItemStack ClientModOffences(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("ClientModOffensesItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("ClientModOffensesName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("ClientModOffensesLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("ClientModOffensesItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("ClientModOffensesName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("ClientModOffensesLore")
+        );
     }
     
     public static ItemStack GeneralOffences(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("GeneralOffensesItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("GeneralOffensesName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("GeneralOffensesLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("GeneralOffensesItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("GeneralOffensesName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("GeneralOffensesLore")
+        );
     }
     
     public static ItemStack ChatOffences(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("ChatOffensesItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("ChatOffensesName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("ChatOffensesLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("ChatOffensesItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("ChatOffensesName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("ChatOffensesLore")
+        );
     }
     
     
     public static ItemStack PermMute(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("PermanentMuteItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("PermanentMuteName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("PermanentMuteLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("PermanentMuteItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("PermanentMuteName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("PermanentMuteLore")
+        );
     }
     public static ItemStack PermBan(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("PermanentBanItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("PermanentBanName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("PermanentBanLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("PermanentBanItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("PermanentBanName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("PermanentBanLore")
+        );
     }
 
     public static ItemStack IPBan(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("IPBanItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("IPBanName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("IPBanLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("IPBanItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("IPBanName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("IPBanLore")
+        );
     }
     public static ItemStack IPMute(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("IPMuteItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("IPMuteName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("IPMuteLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("IPMuteItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("IPMuteName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("IPMuteLore")
+        );
     }
     
     public static ItemStack Severity1Mute(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("Severity1MuteItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("Severity1MuteName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("Severity1MuteLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("Severity1MuteItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("Severity1MuteName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("Severity1MuteLore")
+        );
     }
 
     public static ItemStack Warning(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("WarningItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("WarningName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("WarningLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("WarningItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("WarningName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("WarningLore")
+        );
     }
     
     public static ItemStack Severity1GeneralBan(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("Severity1GeneralBanItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("Severity1GeneralBanName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("Severity1GeneralBanLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("Severity2ClientBanItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("Severity2ClientBanName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("Severity2ClientBanLore")
+        );
     }
     
     public static ItemStack Severity1ClientBan(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("Severity1ClientBanItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("Severity1ClientBanName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("Severity1ClientBanLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("Severity1ClientBanItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("Severity1ClientBanName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("Severity1ClientBanLore")
+        );
+
     }
     public static ItemStack Severity2Mute(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("Severity2MuteItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("Severity2MuteName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("Severity2MuteLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("Severity2MuteItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("Severity2MuteName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("Severity2MuteLore")
+        );
     }
     public static ItemStack Severity2ClientBan(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("Severity2ClientBanItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("Severity2ClientBanName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("Severity2ClientBanLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("Severity2ClientBanItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("Severity2ClientBanName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("Severity2ClientBanLore")
+        );
     }
     public static ItemStack Severity3Mute(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("Severity3MuteItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("Severity3MuteName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("Severity3MuteLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("Severity3MuteItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("Severity3MuteName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("Severity3MuteLore")
+        );
     }
     public static ItemStack Severity3ClientBan(Player p) {
-        ItemStack stone = new ItemStack(Material.getMaterial(PunishmentGUI.plugin.getguiitems1Config().getString("Severity3ClientBanItem")));
-        ItemMeta stonem = stone.getItemMeta();
-        stonem.setDisplayName(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.plugin.getguiitems1Config().getString("Severity3ClientBanName")));
-        ArrayList<String> lore = new ArrayList<>();
-        List<String> stringList = PunishmentGUI.plugin.getguiitems1Config().getStringList("Severity3ClientBanLore");
-        IntStream.range(0, stringList.size()).forEach(i -> lore.add(getColor(stringList.get(i))));
-        stonem.setLore(lore);
-        stone.setItemMeta(stonem);
-        return stone;
+        return createItemFromConfig(
+            PunishmentGUI.plugin.getguiitems1Config().getString("Severity3ClientBanItem"),
+            PunishmentGUI.plugin.getguiitems1Config().getString("Severity3ClientBanName"),
+            PunishmentGUI.plugin.getguiitems1Config().getStringList("Severity3ClientBanLore")
+        );
     }
     
 }

--- a/src/main/java/me/noodles/gui/util/config/CustomConfig.java
+++ b/src/main/java/me/noodles/gui/util/config/CustomConfig.java
@@ -1,0 +1,77 @@
+package me.noodles.gui.util.config;
+
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+
+public final class CustomConfig implements IConfig {
+  private FileConfiguration newConfig = null;
+  private File configFile = null;
+  private String configName;
+  private JavaPlugin plugin;
+
+  public CustomConfig(JavaPlugin plugin, String configName) {
+    this.configName = configName;
+    this.plugin = plugin;
+
+    this.createConfig();
+  }
+
+  private void createConfig() {
+    this.configFile = new File(this.plugin.getDataFolder(), this.configName);
+
+    this.saveDefaultConfig();
+
+    this.newConfig = new YamlConfiguration();
+
+    try {
+      this.newConfig.load(this.configFile);
+    }  catch (IOException | InvalidConfigurationException e) {
+      this.plugin.getLogger().severe(e.getMessage());
+      e.printStackTrace();
+    }
+  }
+
+  public FileConfiguration getConfig() {
+    if (this.newConfig == null) this.reloadConfig();
+    return this.newConfig;
+  }
+
+  public void reloadConfig() {
+    this.newConfig = YamlConfiguration.loadConfiguration(this.configFile);
+
+    final Reader configReader = new InputStreamReader(this.plugin.getResource(this.configName), StandardCharsets.UTF_8);
+
+    final YamlConfiguration defaultConfig = YamlConfiguration.loadConfiguration(configReader);
+
+    this.newConfig.setDefaults(defaultConfig);
+    this.newConfig.options().copyDefaults(true);
+  }
+
+  /**
+   * Save config removes comments, use with caution.
+   */
+  @Deprecated
+  public void saveConfig() {
+    try {
+      getConfig().save(this.configFile);
+    } catch (IOException exception) {
+      this.plugin.getLogger().warning(exception.getMessage());
+    }
+  }
+
+  public void saveDefaultConfig() {
+    if (this.configFile == null) { new File(this.plugin.getDataFolder(), this.configName); }
+    if (!this.configFile.exists()) {
+      this.configFile.getParentFile().mkdirs();
+      this.plugin.saveResource(this.configName, false);
+    }
+  }
+}

--- a/src/main/java/me/noodles/gui/util/config/IConfig.java
+++ b/src/main/java/me/noodles/gui/util/config/IConfig.java
@@ -1,0 +1,10 @@
+package me.noodles.gui.util.config;
+
+import org.bukkit.configuration.file.FileConfiguration;
+
+public interface IConfig {
+  public FileConfiguration getConfig();
+  public void reloadConfig();
+  public void saveConfig();
+  public void saveDefaultConfig();
+}

--- a/src/main/resources/guiitems.yml
+++ b/src/main/resources/guiitems.yml
@@ -3,6 +3,9 @@
 #=======================================================
 #Sections:
 
+#Filler:
+GUIFillerItem: "STAINED_GLASS_PANE:7"
+
 #ClientModOffenses:
 ClientModOffensesItem: "IRON_SWORD"
 ClientModOffensesLocation: 14


### PR DESCRIPTION
Added support to use byte data to access block variants, and the ability to set the GUI filler block.
Block variant can be accessed by using the said syntax `"block:byte"` e.g. `"WOOL:3"` if the byte is not added, we set a default byte to 0, which is the default byte for all blocks.
Only tested on 1.8 and 1.15.2, should be tested on major usage versions before adding to source.