### PR TITLE
[WIP] Fix multiple inventories overwriting ban target issue

### DIFF
--- a/src/main/java/me/noodles/gui/PunishmentGUI.java
+++ b/src/main/java/me/noodles/gui/PunishmentGUI.java
@@ -2,6 +2,8 @@ package me.noodles.gui;
 
 import me.noodles.gui.commands.PunishmentGUICommand;
 import me.noodles.gui.commands.PunishmentGUIReloadCommand;
+import me.noodles.gui.listeners.LeaveEvent;
+import me.noodles.gui.manager.BannedManager;
 import me.noodles.gui.util.config.CustomConfig;
 import me.noodles.gui.util.config.IConfig;
 import me.noodles.gui.util.Logger;
@@ -11,13 +13,14 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import me.noodles.gui.commands.Punish;
-import me.noodles.gui.updatechecker.JoinEvents;
+import me.noodles.gui.listeners.JoinEvents;
 import me.noodles.gui.updatechecker.UpdateChecker;
 
 public class PunishmentGUI extends JavaPlugin {
     private static PunishmentGUI plugin;
 
     private IConfig customConfig, guiConfig, banConfig, guiCommands;
+    private BannedManager bannedPlayersManager = BannedManager.getManager();
 
     public void onEnable() {
         Logger.log(Logger.LogLevel.OUTLINE,  "*********************************************************************");
@@ -60,10 +63,16 @@ public class PunishmentGUI extends JavaPlugin {
         });
     }
 
+    @Override
+    public void onDisable() {
+        getBannedManager().clear();
+    }
+
     public void registerEvents() {
         final PluginManager pm = this.getServer().getPluginManager();
         pm.registerEvents(new Punish(), this);
         pm.registerEvents(new JoinEvents(), this);
+        pm.registerEvents(new LeaveEvent(), this);
     }
 
     public void registerCommands() {
@@ -97,5 +106,7 @@ public class PunishmentGUI extends JavaPlugin {
         banConfig = new CustomConfig(this, "banreason.yml");
         guiCommands = new CustomConfig(this, "guicommands.yml");
     }
+
+    public BannedManager getBannedManager() { return this.bannedPlayersManager; }
 
 }

--- a/src/main/java/me/noodles/gui/commands/Punish.java
+++ b/src/main/java/me/noodles/gui/commands/Punish.java
@@ -16,11 +16,6 @@ import me.noodles.gui.inv.Items;
 import me.noodles.gui.PunishmentGUI;
 
 public class Punish implements Listener, CommandExecutor {
-	public static String bannedPlayer;
-
-	public Punish() {
-		bannedPlayer = null;
-	}
 
 	public boolean onCommand(CommandSender sender, Command cmd, String commandLabel, String[] args) {
 		if (!(sender instanceof Player)) {
@@ -40,7 +35,7 @@ public class Punish implements Listener, CommandExecutor {
 		}
 
 		if (args.length == 1) {
-			bannedPlayer = args[0];
+			PunishmentGUI.getPlugin().getBannedManager().add(p.getUniqueId(), args[0]);
 		}
 
 		if (!sender.hasPermission("punish.use")) {
@@ -53,7 +48,7 @@ public class Punish implements Listener, CommandExecutor {
 			return true;
 		}
 
-		if(bannedPlayer.length() > 16){
+		if(PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId()).length() > 16){
 			sender.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("NameLength")));
 			return true;
 		}
@@ -101,76 +96,101 @@ public class Punish implements Listener, CommandExecutor {
 		if (e.getView().getTitle().equals(InvNames.Main)) {
 			e.setCancelled(true);
 			if (e.getCurrentItem().equals(Items.PermMute(p))) {
-				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("PermMuteCommand").replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("PermMuteReason")).replace("%target%", bannedPlayer));
-				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("PermMuteMessage").replace("%player%", bannedPlayer)));
+				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("PermMuteCommand").replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("PermMuteReason")).replace("%target%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId())));
+				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("PermMuteMessage").replace("%player%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId()))));
 				p.closeInventory();
+
+				PunishmentGUI.getPlugin().getBannedManager().remove(p.getUniqueId());
 			}
 
 			if (e.getCurrentItem().equals(Items.Severity1Mute(p))) {
-				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("Severity1MuteCommand").replace("%t%", PunishmentGUI.getPlugin().getBanReason().getString("Severity1MuteTime")).replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("Severity1MuteReason")).replace("%target%", bannedPlayer));
-				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("Severity1MuteMessage").replace("%player%", bannedPlayer)));
+				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("Severity1MuteCommand").replace("%t%", PunishmentGUI.getPlugin().getBanReason().getString("Severity1MuteTime")).replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("Severity1MuteReason")).replace("%target%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId())));
+				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("Severity1MuteMessage").replace("%player%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId()))));
 				p.closeInventory();
+
+				PunishmentGUI.getPlugin().getBannedManager().remove(p.getUniqueId());
 			}
 
 			if (e.getCurrentItem().equals(Items.Severity1GeneralBan(p))) {
-				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("Severity1GeneralBanCommand").replace("%t%", PunishmentGUI.getPlugin().getBanReason().getString("Severity1GeneralBanTime")).replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("Severity1GeneralBanReason")).replace("%target%", bannedPlayer));
-				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("Severity1GeneralBanMessage").replace("%player%", bannedPlayer)));
+				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("Severity1GeneralBanCommand").replace("%t%", PunishmentGUI.getPlugin().getBanReason().getString("Severity1GeneralBanTime")).replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("Severity1GeneralBanReason")).replace("%target%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId())));
+				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("Severity1GeneralBanMessage").replace("%player%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId()))));
 				p.closeInventory();
+
+				PunishmentGUI.getPlugin().getBannedManager().remove(p.getUniqueId());
 			}
 
 			if (e.getCurrentItem().equals(Items.Severity1ClientBan(p))) {
-				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("Severity1ClientBanCommand").replace("%t%", PunishmentGUI.getPlugin().getBanReason().getString("Severity1ClientBanTime")).replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("Severity1ClientBanReason")).replace("%target%", bannedPlayer));
-				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("Severity1ClientBanMessage").replace("%player%", bannedPlayer)));
+				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("Severity1ClientBanCommand").replace("%t%", PunishmentGUI.getPlugin().getBanReason().getString("Severity1ClientBanTime")).replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("Severity1ClientBanReason")).replace("%target%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId())));
+				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("Severity1ClientBanMessage").replace("%player%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId()))));
 				p.closeInventory();
+
+				PunishmentGUI.getPlugin().getBannedManager().remove(p.getUniqueId());
 			}
 
 			if (e.getCurrentItem().equals(Items.Severity2Mute(p))) {
-				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("Severity2MuteCommand").replace("%t%", PunishmentGUI.getPlugin().getBanReason().getString("Severity2MuteTime")).replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("Severity2MuteReason")).replace("%target%", bannedPlayer));
-				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("Severity2MuteMessage").replace("%player%", bannedPlayer)));
+				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("Severity2MuteCommand").replace("%t%", PunishmentGUI.getPlugin().getBanReason().getString("Severity2MuteTime")).replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("Severity2MuteReason")).replace("%target%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId())));
+				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("Severity2MuteMessage").replace("%player%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId()))));
 				p.closeInventory();
+
+				PunishmentGUI.getPlugin().getBannedManager().remove(p.getUniqueId());
 			}
 
 			if (e.getCurrentItem().equals(Items.Severity3Mute(p))) {
-				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("Severity3MuteCommand").replace("%t%", PunishmentGUI.getPlugin().getBanReason().getString("Severity3MuteTime")).replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("Severity3MuteReason")).replace("%target%", bannedPlayer));
-				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("Severity3MuteMessage").replace("%player%", bannedPlayer)));
+				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("Severity3MuteCommand").replace("%t%", PunishmentGUI.getPlugin().getBanReason().getString("Severity3MuteTime")).replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("Severity3MuteReason")).replace("%target%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId())));
+				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("Severity3MuteMessage").replace("%player%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId()))));
 				p.closeInventory();
+
+				PunishmentGUI.getPlugin().getBannedManager().remove(p.getUniqueId());
 			}
 
 			if (e.getCurrentItem().equals(Items.Severity2ClientBan(p))) {
-				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("Severity2ClientBanCommand").replace("%t%", PunishmentGUI.getPlugin().getBanReason().getString("Severity2ClientBanTime")).replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("Severity2ClientBanReason")).replace("%target%", bannedPlayer));
-				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("Severity2ClientBanMessage").replace("%player%", bannedPlayer)));
+				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("Severity2ClientBanCommand").replace("%t%", PunishmentGUI.getPlugin().getBanReason().getString("Severity2ClientBanTime")).replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("Severity2ClientBanReason")).replace("%target%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId())));
+				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("Severity2ClientBanMessage").replace("%player%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId()))));
 				p.closeInventory();
+
+				PunishmentGUI.getPlugin().getBannedManager().remove(p.getUniqueId());
 			}
 
 			if (e.getCurrentItem().equals(Items.Severity3ClientBan(p))) {
-				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("Severity3ClientBanCommand").replace("%t%", PunishmentGUI.getPlugin().getBanReason().getString("Severity3ClientBanTime")).replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("Severity3ClientBanReason")).replace("%target%", bannedPlayer));
-				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("Severity3ClientBanMessage").replace("%player%", bannedPlayer)));
+				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("Severity3ClientBanCommand").replace("%t%", PunishmentGUI.getPlugin().getBanReason().getString("Severity3ClientBanTime")).replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("Severity3ClientBanReason")).replace("%target%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId())));
+				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("Severity3ClientBanMessage").replace("%player%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId()))));
 				p.closeInventory();
+
+				PunishmentGUI.getPlugin().getBannedManager().remove(p.getUniqueId());
 			}
 
 			if (e.getCurrentItem().equals(Items.PermBan(p))) {
-				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("PermBanCommand").replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("PermBanReason")).replace("%target%", bannedPlayer));
-				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("PermBanMessage").replace("%player%", bannedPlayer)));
+				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("PermBanCommand").replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("PermBanReason")).replace("%target%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId())));
+				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("PermBanMessage").replace("%player%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId()))));
 				p.closeInventory();
+
+				PunishmentGUI.getPlugin().getBannedManager().remove(p.getUniqueId());
 			}
 
 			if (e.getCurrentItem().equals(Items.IPMute(p))) {
-				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("IPMuteCommand").replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("IPMuteReason")).replace("%target%", bannedPlayer));
-				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("IPMuteMessage").replace("%player%", bannedPlayer)));
+				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("IPMuteCommand").replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("IPMuteReason")).replace("%target%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId())));
+				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("IPMuteMessage").replace("%player%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId()))));
 				p.closeInventory();
+
+				PunishmentGUI.getPlugin().getBannedManager().remove(p.getUniqueId());
 			}
 
 			if (e.getCurrentItem().equals(Items.IPBan(p))) {
-				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("IPBanCommand").replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("IPBanReason")).replace("%target%", bannedPlayer));
-				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("IPBanMessage").replace("%player%", bannedPlayer)));
+				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("IPBanCommand").replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("IPBanReason")).replace("%target%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId())));
+				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("IPBanMessage").replace("%player%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId()))));
 				p.closeInventory();
+
+				PunishmentGUI.getPlugin().getBannedManager().remove(p.getUniqueId());
 			}
 
 			if (e.getCurrentItem().equals(Items.Warning(p))) {
-				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("WarnCommand").replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("WarnReason")).replace("%target%", bannedPlayer));
-				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("WarnMessage").replace("%player%", bannedPlayer)));
+				p.chat(PunishmentGUI.getPlugin().getGuiCommands().getString("WarnCommand").replace("%reason%", PunishmentGUI.getPlugin().getBanReason().getString("WarnReason")).replace("%target%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId())));
+				p.sendMessage(ChatColor.translateAlternateColorCodes('&', PunishmentGUI.getPlugin().getConfig().getString("Prefix") + PunishmentGUI.getPlugin().getBanReason().getString("WarnMessage").replace("%player%", PunishmentGUI.getPlugin().getBannedManager().get(p.getUniqueId()))));
 				p.closeInventory();
+
+				PunishmentGUI.getPlugin().getBannedManager().remove(p.getUniqueId());
 			}
+
 		}
 	}
 

--- a/src/main/java/me/noodles/gui/listeners/InvCloseEvent.java
+++ b/src/main/java/me/noodles/gui/listeners/InvCloseEvent.java
@@ -1,0 +1,19 @@
+package me.noodles.gui.listeners;
+
+import me.noodles.gui.PunishmentGUI;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+
+public class InvCloseEvent implements Listener {
+
+    @EventHandler
+    public void onInventoryClose(final InventoryCloseEvent event) {
+        final Player player = (Player) event.getPlayer();
+
+        if (PunishmentGUI.getPlugin().getBannedManager().contains(player.getUniqueId())) {
+            PunishmentGUI.getPlugin().getBannedManager().remove(player.getUniqueId());
+        }
+    }
+}

--- a/src/main/java/me/noodles/gui/listeners/JoinEvents.java
+++ b/src/main/java/me/noodles/gui/listeners/JoinEvents.java
@@ -1,5 +1,6 @@
-package me.noodles.gui.updatechecker;
+package me.noodles.gui.listeners;
 
+import me.noodles.gui.updatechecker.UpdateChecker;
 import me.noodles.gui.util.Settings;
 import org.bukkit.event.player.*;
 

--- a/src/main/java/me/noodles/gui/listeners/LeaveEvent.java
+++ b/src/main/java/me/noodles/gui/listeners/LeaveEvent.java
@@ -1,0 +1,29 @@
+package me.noodles.gui.listeners;
+
+import me.noodles.gui.PunishmentGUI;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerKickEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class LeaveEvent implements Listener {
+
+    @EventHandler
+    public void onPlayerKick(final PlayerKickEvent event) {
+        final Player player = event.getPlayer();
+
+        if (PunishmentGUI.getPlugin().getBannedManager().contains(player.getUniqueId())) {
+            PunishmentGUI.getPlugin().getBannedManager().remove(player.getUniqueId());
+        }
+    }
+
+    @EventHandler
+    public void onPlayerQuit(final PlayerQuitEvent event) {
+        final Player player = event.getPlayer();
+
+        if (PunishmentGUI.getPlugin().getBannedManager().contains(player.getUniqueId())) {
+            PunishmentGUI.getPlugin().getBannedManager().remove(player.getUniqueId());
+        }
+    }
+}

--- a/src/main/java/me/noodles/gui/manager/BannedManager.java
+++ b/src/main/java/me/noodles/gui/manager/BannedManager.java
@@ -1,0 +1,47 @@
+package me.noodles.gui.manager;
+
+import java.util.*;
+
+public class BannedManager {
+    private static volatile BannedManager INSTANCE;
+
+    private Map<UUID, String> players = new HashMap<>();
+
+    private BannedManager() { }
+
+    public void add(final UUID uuid, final String player) {
+        players.put(uuid, player);
+    }
+
+    public String get(final UUID uuid) {
+        return Optional.ofNullable(players.get(uuid)).orElseThrow(NoSuchElementException::new);
+    }
+
+    public void remove(final UUID uuid) {
+        players.remove(uuid);
+    }
+
+    public boolean contains(final UUID uuid) {
+        return players.containsKey(uuid);
+    }
+
+    public void clear() {
+        players.clear();
+    }
+
+    public static BannedManager getManager() {
+        BannedManager manager = INSTANCE;
+
+        if (manager == null) {
+            synchronized (BannedManager.class) {
+                manager = INSTANCE;
+                if (manager == null) {
+                    INSTANCE = manager = new BannedManager();
+                }
+            }
+        }
+
+        return INSTANCE;
+    }
+
+}

--- a/src/main/java/me/noodles/gui/manager/BannedManager.java
+++ b/src/main/java/me/noodles/gui/manager/BannedManager.java
@@ -13,9 +13,7 @@ public class BannedManager {
         players.put(uuid, player);
     }
 
-    public String get(final UUID uuid) {
-        return Optional.ofNullable(players.get(uuid)).orElseThrow(NoSuchElementException::new);
-    }
+    public String get(final UUID uuid) { return players.get(uuid); }
 
     public void remove(final UUID uuid) {
         players.remove(uuid);


### PR DESCRIPTION
Rewrote how we handle the banned player state, introduced a singleton manager that holds the current admin users UUID and the player name, also added some events to remove the UUID if it's still in the HashMap if for instance we log out or get kicked and so on, or if we close the inventory without banning a player.